### PR TITLE
Fixes problem with limit of 52 chars for name

### DIFF
--- a/helm_deploy/hmpps-strengths-based-needs-assessments-api/templates/data-extractor-job.yaml
+++ b/helm_deploy/hmpps-strengths-based-needs-assessments-api/templates/data-extractor-job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: {{ .Release.Name }}-analytics-extractor
+  name: hmpps-sbna-analytics-extractor
   labels:
     app: hmpps-strengths-based-needs-assessment
     release: {{ .Release.Name }}


### PR DESCRIPTION
"No-one will ever need more than 52 characters"

Error: UPGRADE FAILED: failed to create resource: CronJob.batch "hmpps-strengths-based-needs-assessments-api-analytics-extractor" is invalid: metadata.name: Invalid value: "hmpps-strengths-based-needs-assessments-api-analytics-extractor": must be no more than 52 characters