### PR TITLE
ARN-2291 Revert Java version back to 21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,13 +224,13 @@ workflows:
           helm_timeout: 5m
 
   security:
-#    triggers:
-#      - schedule:
-#          cron: "11 8 * * 1-5"
-#          filters:
-#            branches:
-#              only:
-#                - main
+    triggers:
+      - schedule:
+          cron: "11 8 * * 1-5"
+          filters:
+            branches:
+              only:
+                - main
     jobs:
       - hmpps/gradle_owasp_dependency_check:
           jdk_tag: "21.0"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,6 @@ parameters:
   releases-slack-channel:
     type: string
     default: hmpps-strengths-based-needs-assessments-alerts
-  node-version:
-    type: string
-    default: 20.8-browsers
   deploy:
     description: Trigger a manual deployment
     type: string
@@ -236,7 +233,7 @@ workflows:
 #                - main
     jobs:
       - hmpps/gradle_owasp_dependency_check:
-          jdk_tag: "20.0"
+          jdk_tag: "21.0"
           slack_channel: << pipeline.parameters.alerts-slack-channel >>
           context:
             - hmpps-common-vars

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,16 +227,16 @@ workflows:
           helm_timeout: 5m
 
   security:
-    triggers:
-      - schedule:
-          cron: "11 8 * * 1-5"
-          filters:
-            branches:
-              only:
-                - main
+#    triggers:
+#      - schedule:
+#          cron: "11 8 * * 1-5"
+#          filters:
+#            branches:
+#              only:
+#                - main
     jobs:
       - hmpps/gradle_owasp_dependency_check:
-          jdk_tag: "22.0"
+          jdk_tag: "21.0"
           slack_channel: << pipeline.parameters.alerts-slack-channel >>
           context:
             - hmpps-common-vars

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,7 +236,7 @@ workflows:
 #                - main
     jobs:
       - hmpps/gradle_owasp_dependency_check:
-          jdk_tag: "21.0"
+          jdk_tag: "20.0"
           slack_channel: << pipeline.parameters.alerts-slack-channel >>
           context:
             - hmpps-common-vars

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM gradle:8-jdk22-alpine AS builder
+FROM gradle:8-jdk21-alpine AS builder
 
-FROM eclipse-temurin:22-jre-alpine AS runtime
+FROM eclipse-temurin:21-jre-alpine AS runtime
 
 FROM builder AS build
 WORKDIR /app

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,9 @@ test-unit: ## Runs the unit test suite.
 test-integration: ## Runs the integration test suite.
 	docker compose ${DEV_COMPOSE_FILES} exec api gradle integrationTests --parallel
 
+test-dependency:
+	docker compose ${DEV_COMPOSE_FILES} exec api gradle dependencyCheckUpdate dependencyCheckAnalyze
+
 lint: ## Runs the Kotlin linter.
 # TODO: re-enable Detekt when it supports Kotlin 2.0
 # 	docker compose ${DEV_COMPOSE_FILES} exec api gradle ktlintCheck detekt --parallel

--- a/Makefile
+++ b/Makefile
@@ -50,9 +50,6 @@ test-unit: ## Runs the unit test suite.
 test-integration: ## Runs the integration test suite.
 	docker compose ${DEV_COMPOSE_FILES} exec api gradle integrationTests --parallel
 
-test-dependency:
-	docker compose ${DEV_COMPOSE_FILES} exec api gradle dependencyCheckUpdate dependencyCheckAnalyze
-
 lint: ## Runs the Kotlin linter.
 # TODO: re-enable Detekt when it supports Kotlin 2.0
 # 	docker compose ${DEV_COMPOSE_FILES} exec api gradle ktlintCheck detekt --parallel

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,12 +51,12 @@ dependencies {
 }
 
 kotlin {
-  jvmToolchain(22)
+  jvmToolchain(21)
 }
 
 tasks {
   withType<KotlinCompile> {
-    compilerOptions.jvmTarget = JvmTarget.JVM_22
+    compilerOptions.jvmTarget = JvmTarget.JVM_21
   }
   withType<BootRun> {
     jvmArgs = listOf(


### PR DESCRIPTION
Having to revert Java back to v21 because cimg/openjdk:22.0 does not exist (used by hmpps Gradle OWASP dependency check)