### PR TITLE
Removes a dependency constraint now that the problem has been patched upstream

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,11 +20,6 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-security")
   implementation("org.springframework.security:spring-security-oauth2-client")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
-  constraints {
-    implementation("com.nimbusds:nimbus-jose-jwt:10.2") {
-      because("previous versions have a high vulnerability CVE-2023-52428")
-    }
-  }
 
   // Database dependencies
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")


### PR DESCRIPTION
I manually ran Trivy before and after this change and it returned the same result.